### PR TITLE
Fix incorrect validation for `fork_policy` element

### DIFF
--- a/bitbucket/resource_bitbucket_repository.go
+++ b/bitbucket/resource_bitbucket_repository.go
@@ -56,7 +56,7 @@ func resourceBitBucketRepository() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "no_forks",
-				ValidateFunc: validation.StringNotInSlice([]string{"allow_forks", "no_public_forks", "no_forks"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"allow_forks", "no_public_forks", "no_forks"}, false),
 				DiffSuppressFunc: func(k, old, new string, resourceData *schema.ResourceData) bool {
 					return resourceData.Get("is_private").(bool) == false
 				},


### PR DESCRIPTION
Sadly the wrong validator was picked, we wanted the inverse, we wanted to match these values only.