### PR TITLE
GH-25 Add user data source

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:

--- a/bitbucket/data_source_bitbucket_user.go
+++ b/bitbucket/data_source_bitbucket_user.go
@@ -1,0 +1,94 @@
+package bitbucket
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	gobb "github.com/ktrysmt/go-bitbucket"
+)
+
+func dataSourceBitbucketUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBitbucketUserRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The User's UUID.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"nickname": {
+				Description: "The User's nickname.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"display_name": {
+				Description: "The User's display name.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"account_id": {
+				Description: "The User's account ID.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"account_status": {
+				Description: "The User's account status. Will be one of active, inactive or closed.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceBitbucketUserRead(ctx context.Context, resourceData *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*gobb.Client)
+
+	userResponse, err := client.Users.Get(resourceData.Get("id").(string))
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to get user with error: %s", err))
+	}
+
+	user, err := decodeUserResponse(userResponse)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to decode user response with error: %s", err))
+	}
+
+	_ = resourceData.Set("nickname", user.Nickname)
+	_ = resourceData.Set("display_name", user.DisplayName)
+	_ = resourceData.Set("account_id", user.AccountId)
+	_ = resourceData.Set("account_status", user.AccountStatus)
+	resourceData.SetId(user.Uuid)
+
+	return nil
+}
+
+type User struct {
+	Uuid          string
+	DisplayName   string `json:"display_name"`
+	Nickname      string
+	AccountId     string `json:"account_id"`
+	AccountStatus string `json:"account_status"`
+}
+
+func decodeUserResponse(response interface{}) (*User, error) {
+	userMap := response.(map[string]interface{})
+
+	if userMap["type"] == "error" {
+		return nil, errors.New("unable able to decode user API response")
+	}
+
+	user := &User{}
+	jsonString, err := json.Marshal(userMap)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(jsonString, &user)
+
+	return user, err
+}

--- a/bitbucket/data_source_bitbucket_user_test.go
+++ b/bitbucket/data_source_bitbucket_user_test.go
@@ -1,0 +1,52 @@
+package bitbucket
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	gobb "github.com/ktrysmt/go-bitbucket"
+)
+
+func TestAccBitbucketUserDataSource_basic(t *testing.T) {
+	user, _ := getCurrentUser()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "bitbucket_user" "testacc" {
+						id = "%s"
+					}`, user.Uuid),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.bitbucket_user.testacc", "nickname", user.Nickname),
+					resource.TestCheckResourceAttr("data.bitbucket_user.testacc", "display_name", user.DisplayName),
+					resource.TestCheckResourceAttr("data.bitbucket_user.testacc", "account_status", user.AccountStatus),
+					resource.TestCheckResourceAttrSet("data.bitbucket_user.testacc", "id"),
+					resource.TestCheckResourceAttrSet("data.bitbucket_user.testacc", "account_id"),
+				),
+			},
+		},
+	})
+}
+
+func getCurrentUser() (*gobb.User, error) {
+	if _, isSet := os.LookupEnv("TF_ACC"); isSet {
+		client := gobb.NewBasicAuth(
+			os.Getenv("BITBUCKET_USERNAME"),
+			os.Getenv("BITBUCKET_PASSWORD"),
+		)
+
+		return client.User.Profile()
+	} else {
+		return &gobb.User{
+			Uuid:          "",
+			Nickname:      "",
+			DisplayName:   "",
+			AccountStatus: "",
+		}, nil
+	}
+}

--- a/bitbucket/provider.go
+++ b/bitbucket/provider.go
@@ -28,6 +28,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"bitbucket_project":    dataSourceBitbucketProject(),
 			"bitbucket_repository": dataSourceBitbucketRepository(),
+			"bitbucket_user":       dataSourceBitbucketUser(),
 			"bitbucket_webhook":    dataSourceBitbucketWebhook(),
 			"bitbucket_workspace":  dataSourceBitbucketWorkspace(),
 		},

--- a/docs/data-sources/bitbucket_user.md
+++ b/docs/data-sources/bitbucket_user.md
@@ -1,0 +1,20 @@
+# Data Source: bitbucket_user
+Use this data source to get the user resource, you can then reference its attributes without having to hardcode them.
+
+## Example Usage
+```hcl
+data "bitbucket_user" "example" {
+  id = "{user-uuid}"
+}
+```
+
+## Argument Reference
+The following arguments are supported:
+* `id` - (Required) The User's UUID.
+
+## Attribute Reference
+In addition to the arguments above, the following additional attributes are exported:
+* `nickname` - The User's nickname.
+* `display_name` - The User's display name.
+* `account_id` - The User's account ID.
+* `account_status` - The User's account status. Will be one of active, inactive or closed.


### PR DESCRIPTION
Along with docs & disabled running CodeQL action when changes are pushed to the main branch, since they will always come via PRs anyway, no point running CodeQL twice.