### PR TITLE
GH-40 Implement deprecated Group & Group Privileges endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ build:
 	@echo ""
 	@echo "This should only be used during development. See https://www.terraform.io/docs/commands/cli-config.html#development-overrides-for-provider-developers for details."
 
+lint:
+	golangci-lint run
+
 test:
 	go test -v -cover ./...
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ are more than welcome to submit a pull request or raise a ticket if you'd prefer
 ### Requirements
 If you do wish to help develop this, you will need the following installed:
 * [Go](http://www.golang.org) (see `go.mod` file for the correct version to install)
+* [Go Linter](https://formulae.brew.sh/formula/golangci-lint)
 * [GOPATH](http://golang.org/doc/code.html#GOPATH) (is correctly setup)
 * [Terraform](https://www.terraform.io/downloads.html) (0.14+)
 

--- a/bitbucket/api/v1/client.go
+++ b/bitbucket/api/v1/client.go
@@ -1,0 +1,39 @@
+package v1
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+)
+
+type Client struct {
+	Auth *Auth
+
+	ApiBaseUrl *url.URL
+	HttpClient *http.Client
+
+	Groups          *Groups
+	GroupPrivileges *GroupPrivileges
+}
+
+type Auth struct {
+	Username string
+	Password string
+}
+
+func NewClient(auth *Auth) *Client {
+	apiBaseUrl, err := url.Parse("https://api.bitbucket.org/1.0")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	client := &Client{
+		Auth:       auth,
+		ApiBaseUrl: apiBaseUrl,
+	}
+	client.Groups = &Groups{client: client}
+	client.GroupPrivileges = &GroupPrivileges{client: client}
+	client.HttpClient = new(http.Client)
+
+	return client
+}

--- a/bitbucket/api/v1/group_privileges.go
+++ b/bitbucket/api/v1/group_privileges.go
@@ -1,0 +1,121 @@
+package v1
+
+// Implements: https://support.atlassian.com/bitbucket-cloud/docs/group-privileges-endpoint/#Overview
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type GroupPrivileges struct {
+	client *Client
+}
+
+type GroupPrivilege struct {
+	Privilege string `json:"privilege"`
+	Group     struct {
+		Owner struct {
+			Uuid string `json:"uuid"`
+		}
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+	}
+	Repository struct {
+		Owner struct {
+			Uuid string `json:"uuid"`
+		}
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+	}
+}
+
+type GroupPrivilegeOptions struct {
+	WorkspaceId string
+	RepoSlug    string
+	GroupOwner  string
+	GroupSlug   string
+	Privilege   string
+}
+
+func (gp *GroupPrivileges) Get(gpo *GroupPrivilegeOptions) (*GroupPrivilege, error) {
+	url := fmt.Sprintf("%s/group-privileges/%s/%s/%s/%s", gp.client.ApiBaseUrl, gpo.WorkspaceId, gpo.RepoSlug, gpo.GroupOwner, gpo.GroupSlug)
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.SetBasicAuth(gp.client.Auth.Username, gp.client.Auth.Password)
+
+	response, err := gp.client.HttpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response status code was not 200")
+	}
+
+	result := make([]GroupPrivilege, 1)
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		log.Println("Could not unmarshal JSON payload")
+		return nil, err
+	}
+
+	return &result[0], nil
+}
+
+func (gp *GroupPrivileges) Create(gpo *GroupPrivilegeOptions) (*GroupPrivilege, error) {
+	url := fmt.Sprintf("%s/group-privileges/%s/%s/%s/%s", gp.client.ApiBaseUrl, gpo.WorkspaceId, gpo.RepoSlug, gpo.GroupOwner, gpo.GroupSlug)
+	body := strings.NewReader(gpo.Privilege)
+	request, err := http.NewRequest("PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	request.SetBasicAuth(gp.client.Auth.Username, gp.client.Auth.Password)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := gp.client.HttpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response status code was not 200")
+	}
+
+	result := make([]GroupPrivilege, 1)
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		log.Println("Could not unmarshal JSON payload")
+		return nil, err
+	}
+
+	return &result[0], nil
+}
+
+func (gp *GroupPrivileges) Delete(gpo *GroupPrivilegeOptions) error {
+	url := fmt.Sprintf("%s/group-privileges/%s/%s/%s/%s", gp.client.ApiBaseUrl, gpo.WorkspaceId, gpo.RepoSlug, gpo.GroupOwner, gpo.GroupSlug)
+	request, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	request.SetBasicAuth(gp.client.Auth.Username, gp.client.Auth.Password)
+
+	response, err := gp.client.HttpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("invalid status code, reponse was %s", response.Body)
+	}
+
+	return nil
+}

--- a/bitbucket/api/v1/group_privileges_test.go
+++ b/bitbucket/api/v1/group_privileges_test.go
@@ -1,0 +1,158 @@
+package v1
+
+import (
+	"os"
+	"testing"
+
+	gobb "github.com/ktrysmt/go-bitbucket"
+)
+
+func TestGroupPrivileges(t *testing.T) {
+	if os.Getenv("TF_ACC") != "1" {
+		t.Skip("ENV TF_ACC=1 not set")
+	}
+
+	c := NewClient(&Auth{
+		Username: os.Getenv("BITBUCKET_USERNAME"),
+		Password: os.Getenv("BITBUCKET_PASSWORD"),
+	})
+
+	gobbClient := gobb.NewBasicAuth(
+		os.Getenv("BITBUCKET_USERNAME"),
+		os.Getenv("BITBUCKET_PASSWORD"),
+	)
+
+	var group *Group
+	var repo *gobb.Repository
+	var project *gobb.Project
+
+	t.Run("setup", func(t *testing.T) {
+		group, _ = c.Groups.Create(
+			&GroupOptions{
+				OwnerUuid: c.Auth.Username,
+				Name:      "tf-bb-group-test",
+			},
+		)
+		if group == nil {
+			t.Error("The Group could not be created.")
+		}
+
+		project, _ = gobbClient.Workspaces.CreateProject(
+			&gobb.ProjectOptions{
+				Owner:     c.Auth.Username,
+				Name:      "tf-bb-proj-test",
+				Key:       "TF_BB_PROJ_TEST",
+				IsPrivate: true,
+			},
+		)
+		if project == nil {
+			t.Error("The Project could not be created.")
+		}
+
+		repo, _ = gobbClient.Repositories.Repository.Create(
+			&gobb.RepositoryOptions{
+				Owner:      c.Auth.Username,
+				RepoSlug:   "tf-bb-repo-test",
+				ForkPolicy: "no_forks",
+				Project:    project.Key,
+				IsPrivate:  "true",
+			},
+		)
+		if repo == nil {
+			t.Error("The Repository could not be created.")
+		}
+	})
+
+	t.Run("create", func(t *testing.T) {
+		opt := &GroupPrivilegeOptions{
+			WorkspaceId: c.Auth.Username,
+			RepoSlug:    repo.Slug,
+			GroupOwner:  group.Owner.Uuid,
+			GroupSlug:   group.Slug,
+			Privilege:   "write",
+		}
+		groupPrivilege, err := c.GroupPrivileges.Create(opt)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if groupPrivilege.Privilege != "write" {
+			t.Error("The Group Privilege `privilege` attribute does not match the expected value.")
+		}
+		if groupPrivilege.Group.Slug != group.Slug {
+			t.Error("The Group Privilege `group.slug` attribute does not match the expected value.")
+		}
+		if groupPrivilege.Repository.Slug != repo.Slug {
+			t.Error("The Group Privilege `repo.slug` attribute does not match the expected value.")
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		opt := &GroupPrivilegeOptions{
+			WorkspaceId: c.Auth.Username,
+			RepoSlug:    repo.Slug,
+			GroupOwner:  group.Owner.Uuid,
+			GroupSlug:   group.Slug,
+		}
+		groupPrivilege, err := c.GroupPrivileges.Get(opt)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if groupPrivilege.Privilege != "write" {
+			t.Error("The Group Privilege `privilege` attribute does not match the expected value.")
+		}
+		if groupPrivilege.Group.Slug != group.Slug {
+			t.Error("The Group Privilege `group.slug` attribute does not match the expected value.")
+		}
+		if groupPrivilege.Repository.Slug != repo.Slug {
+			t.Error("The Group Privilege `repo.slug` attribute does not match the expected value.")
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		err := c.GroupPrivileges.Delete(
+			&GroupPrivilegeOptions{
+				WorkspaceId: c.Auth.Username,
+				RepoSlug:    repo.Slug,
+				GroupOwner:  group.Owner.Uuid,
+				GroupSlug:   group.Slug,
+			},
+		)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = c.Groups.Delete(
+			&GroupOptions{
+				OwnerUuid: c.Auth.Username,
+				Slug:      group.Slug,
+			},
+		)
+		if err != nil {
+			t.Error(err)
+		}
+
+		_, err = gobbClient.Repositories.Repository.Delete(
+			&gobb.RepositoryOptions{
+				Owner:    c.Auth.Username,
+				RepoSlug: repo.Slug,
+				Project:  project.Key,
+			},
+		)
+		if err != nil {
+			t.Error(err)
+		}
+
+		_, err = gobbClient.Workspaces.DeleteProject(
+			&gobb.ProjectOptions{
+				Owner: c.Auth.Username,
+				Name:  project.Name,
+				Key:   project.Key,
+			},
+		)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}

--- a/bitbucket/api/v1/groups.go
+++ b/bitbucket/api/v1/groups.go
@@ -1,0 +1,159 @@
+package v1
+
+// Implements: https://support.atlassian.com/bitbucket-cloud/docs/groups-endpoint/#Overview
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type Groups struct {
+	client *Client
+}
+
+type Group struct {
+	Owner struct {
+		Uuid string `json:"uuid"`
+	}
+	Name       string `json:"name"`
+	AutoAdd    bool   `json:"auto_add"`
+	Slug       string `json:"slug"`
+	Permission string `json:"permission"`
+}
+
+type GroupOptions struct {
+	OwnerUuid  string
+	Name       string
+	AutoAdd    bool
+	Slug       string
+	Permission string
+}
+
+func (g *Groups) Get(gro *GroupOptions) (*Group, error) {
+	url := fmt.Sprintf("%s/groups?group=%s/%s", g.client.ApiBaseUrl, gro.OwnerUuid, gro.Slug)
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.SetBasicAuth(g.client.Auth.Username, g.client.Auth.Password)
+
+	response, err := g.client.HttpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response status code was not 200")
+	}
+
+	result := make([]Group, 1)
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		log.Println("Could not unmarshal JSON payload")
+		return nil, err
+	}
+
+	return &result[0], nil
+}
+
+func (g *Groups) Create(gro *GroupOptions) (*Group, error) {
+	url := fmt.Sprintf("%s/groups/%s", g.client.ApiBaseUrl, gro.OwnerUuid)
+	body := strings.NewReader(fmt.Sprintf("name=%s", gro.Name))
+	request, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	request.SetBasicAuth(g.client.Auth.Username, g.client.Auth.Password)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := g.client.HttpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response status code was not 200")
+	}
+
+	result := &Group{}
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		log.Println("Could not unmarshal JSON payload")
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (g *Groups) Update(gro *GroupOptions) (*Group, error) {
+	url := fmt.Sprintf("%s/groups/%s/%s", g.client.ApiBaseUrl, gro.OwnerUuid, gro.Slug)
+
+	requestBody := struct {
+		Name       string `json:"name,omitempty"`
+		AutoAdd    bool   `json:"auto_add,omitempty"`
+		Permission string `json:"permission,omitempty"`
+	}{
+		Name:       gro.Name,
+		AutoAdd:    gro.AutoAdd,
+		Permission: gro.Permission,
+	}
+	requestBodyJson, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	requestBodyJsonString := strings.NewReader(string(requestBodyJson))
+	request, err := http.NewRequest("PUT", url, requestBodyJsonString)
+	if err != nil {
+		return nil, err
+	}
+
+	request.SetBasicAuth(g.client.Auth.Username, g.client.Auth.Password)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := g.client.HttpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response status code was not 200")
+	}
+
+	result := &Group{}
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		log.Println("Could not unmarshal JSON payload")
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (g *Groups) Delete(gro *GroupOptions) error {
+	url := fmt.Sprintf("%s/groups/%s/%s", g.client.ApiBaseUrl, gro.OwnerUuid, gro.Slug)
+	request, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	request.SetBasicAuth(g.client.Auth.Username, g.client.Auth.Password)
+
+	response, err := g.client.HttpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("invalid status code, reponse was %s", response.Body)
+	}
+
+	return nil
+}

--- a/bitbucket/api/v1/groups_test.go
+++ b/bitbucket/api/v1/groups_test.go
@@ -1,0 +1,106 @@
+package v1
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGroups(t *testing.T) {
+	if os.Getenv("TF_ACC") != "1" {
+		t.Skip("ENV TF_ACC=1 not set")
+	}
+
+	c := NewClient(&Auth{
+		Username: os.Getenv("BITBUCKET_USERNAME"),
+		Password: os.Getenv("BITBUCKET_PASSWORD"),
+	})
+
+	var groupResourceSlug string
+
+	name := "tf-bb-group-test"
+
+	t.Run("create", func(t *testing.T) {
+		opt := &GroupOptions{
+			OwnerUuid: c.Auth.Username,
+			Name:      name,
+		}
+
+		group, err := c.Groups.Create(opt)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if group.Name != name {
+			t.Error("The Group `name` attribute does not match the expected value.")
+		}
+		if group.AutoAdd != false {
+			t.Error("The Group `auto_add` attribute does not match the expected value.")
+		}
+		if group.Permission != "" {
+			t.Error("The Group `permission` attribute does not match the expected value.")
+		}
+
+		groupResourceSlug = group.Slug
+	})
+
+	t.Run("get", func(t *testing.T) {
+		opt := &GroupOptions{
+			OwnerUuid: c.Auth.Username,
+			Slug:      groupResourceSlug,
+		}
+		group, err := c.Groups.Get(opt)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if group.Name != name {
+			t.Error("The Group `name` attribute does not match the expected value.")
+		}
+		if group.AutoAdd != false {
+			t.Error("The Group `auto_add` attribute does not match the expected value.")
+		}
+		if group.Permission != "" {
+			t.Error("The Group `permission` attribute does not match the expected value.")
+		}
+		if group.Slug != groupResourceSlug {
+			t.Error("The Group `slug` attribute does not match the expected value.")
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		opt := &GroupOptions{
+			OwnerUuid:  c.Auth.Username,
+			Slug:       groupResourceSlug,
+			AutoAdd:    true,
+			Permission: "write",
+		}
+		group, err := c.Groups.Update(opt)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if group.Name != name {
+			t.Error("The Group `name` attribute does not match the expected value.")
+		}
+		if group.AutoAdd != true {
+			t.Error("The Group `auto_add` attribute does not match the expected value.")
+		}
+		if group.Permission != "write" {
+			t.Error("The Group `permission` attribute does not match the expected value.")
+		}
+		if group.Slug != groupResourceSlug {
+			t.Error("The Group `slug` attribute does not match the expected value.")
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		opt := &GroupOptions{
+			OwnerUuid: c.Auth.Username,
+			Slug:      groupResourceSlug,
+		}
+		err := c.Groups.Delete(opt)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}


### PR DESCRIPTION
These v1 endpoints are marked as deprecated by Atlassian since 2018 but are temporarily supported until a v2 replacement is released.

Closes #40 