### PR TITLE
GH-52 Add bitbucket_group_member resource

### DIFF
--- a/bitbucket/api/v1/client.go
+++ b/bitbucket/api/v1/client.go
@@ -13,6 +13,7 @@ type Client struct {
 	HttpClient *http.Client
 
 	Groups          *Groups
+	GroupMembers    *GroupMembers
 	GroupPrivileges *GroupPrivileges
 }
 
@@ -32,6 +33,7 @@ func NewClient(auth *Auth) *Client {
 		ApiBaseUrl: apiBaseUrl,
 	}
 	client.Groups = &Groups{client: client}
+	client.GroupMembers = &GroupMembers{client: client}
 	client.GroupPrivileges = &GroupPrivileges{client: client}
 	client.HttpClient = new(http.Client)
 

--- a/bitbucket/api/v1/group_members.go
+++ b/bitbucket/api/v1/group_members.go
@@ -1,0 +1,92 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// Implements: https://support.atlassian.com/bitbucket-cloud/docs/groups-endpoint/#GET-the-group-members
+
+type GroupMembers struct {
+	client *Client
+}
+
+type GroupMember struct {
+	DisplayName string `json:"display_name"`
+	AccountID   string `json:"account_id"`
+	IsActive    bool   `json:"is_active"`
+	IsTeam      bool   `json:"is_team"`
+	IsStaff     bool   `json:"is_staff"`
+	Avatar      string `json:"avatar"`
+	ResourceURI string `json:"resource_uri"`
+	Nickname    string `json:"nickname"`
+	UUID        string `json:"uuid"`
+}
+
+type GroupMemberOptions struct {
+	OwnerUuid string
+	Slug      string
+	UserUuid  string
+}
+
+func (gm *GroupMembers) Get(gmo *GroupMemberOptions) ([]GroupMember, error) {
+	url := fmt.Sprintf("%s/groups/%s/%s/members", gm.client.ApiBaseUrl, gmo.OwnerUuid, gmo.Slug)
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.SetBasicAuth(gm.client.Auth.Username, gm.client.Auth.Password)
+
+	response, err := gm.client.HttpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response status code was not 200")
+	}
+
+	result := make([]GroupMember, 1)
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		log.Println("Could not unmarshal JSON payload")
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (gm *GroupMembers) Create(gmo *GroupMemberOptions) (*GroupMember, error) {
+	url := fmt.Sprintf("%s/groups/%s/%s/members/%s", gm.client.ApiBaseUrl, gmo.OwnerUuid, gmo.Slug, gmo.UserUuid)
+	request, err := http.NewRequest("PUT", url, strings.NewReader("{}"))
+	if err != nil {
+		return nil, err
+	}
+
+	request.SetBasicAuth(gm.client.Auth.Username, gm.client.Auth.Password)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := gm.client.HttpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response status code was not 200")
+	}
+
+	result := new(GroupMember)
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		log.Println("Could not unmarshal JSON payload")
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/bitbucket/api/v1/group_members.go
+++ b/bitbucket/api/v1/group_members.go
@@ -90,3 +90,23 @@ func (gm *GroupMembers) Create(gmo *GroupMemberOptions) (*GroupMember, error) {
 
 	return result, nil
 }
+
+func (gm *GroupMembers) Delete(gmo *GroupMemberOptions) error {
+	url := fmt.Sprintf("%s/groups/%s/%s/members/%s", gm.client.ApiBaseUrl, gmo.OwnerUuid, gmo.Slug, gmo.UserUuid)
+	request, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	request.SetBasicAuth(gm.client.Auth.Username, gm.client.Auth.Password)
+
+	response, err := gm.client.HttpClient.Do(request)
+	if err != nil {
+		return nil
+	}
+	if response.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("response status code was not 204")
+	}
+
+	return nil
+}

--- a/bitbucket/api/v1/group_members_test.go
+++ b/bitbucket/api/v1/group_members_test.go
@@ -69,6 +69,33 @@ func TestGroupMembers(t *testing.T) {
 		}
 	})
 
+	t.Run("Delete", func(t *testing.T) {
+		err := c.GroupMembers.Delete(
+			&GroupMemberOptions{
+				OwnerUuid: c.Auth.Username,
+				Slug:      group.Slug,
+				UserUuid:  group.Owner.Uuid,
+			},
+		)
+		if err != nil {
+			t.Error(err)
+		}
+
+		members, err := c.GroupMembers.Get(
+			&GroupMemberOptions{
+				OwnerUuid: c.Auth.Username,
+				Slug:      group.Slug,
+			},
+		)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(members) != 0 {
+			t.Error("The GroupMember list contains unexpected members after deleting the member.")
+		}
+	})
+
 	t.Run("teardown", func(t *testing.T) {
 		opt := &GroupOptions{
 			OwnerUuid: c.Auth.Username,

--- a/bitbucket/api/v1/group_members_test.go
+++ b/bitbucket/api/v1/group_members_test.go
@@ -1,0 +1,82 @@
+package v1
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGroupMembers(t *testing.T) {
+	if os.Getenv("TF_ACC") != "1" {
+		t.Skip("ENV TF_ACC=1 not set")
+	}
+
+	c := NewClient(&Auth{
+		Username: os.Getenv("BITBUCKET_USERNAME"),
+		Password: os.Getenv("BITBUCKET_PASSWORD"),
+	})
+
+	var group *Group
+
+	t.Run("setup", func(t *testing.T) {
+		group, _ = c.Groups.Create(
+			&GroupOptions{
+				OwnerUuid: c.Auth.Username,
+				Name:      "tf-bb-group-members-test",
+			},
+		)
+		if group == nil {
+			t.Error("The Group could not be created.")
+		}
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		result, err := c.GroupMembers.Create(
+			&GroupMemberOptions{
+				OwnerUuid: c.Auth.Username,
+				Slug:      group.Slug,
+				UserUuid:  group.Owner.Uuid,
+			},
+		)
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if result == nil {
+			t.Error("Expected result")
+		}
+		if (*result).UUID != group.Owner.Uuid {
+			t.Error("The GroupMember list contains an unexpected member.")
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		members, err := c.GroupMembers.Get(
+			&GroupMemberOptions{
+				OwnerUuid: c.Auth.Username,
+				Slug:      group.Slug,
+			},
+		)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(members) != 1 {
+			t.Error("The GroupMember list contains unexpected members.")
+		}
+		if members[0].UUID != group.Owner.Uuid {
+			t.Error("The GroupMember list contains an unexpected member.")
+		}
+	})
+
+	t.Run("teardown", func(t *testing.T) {
+		opt := &GroupOptions{
+			OwnerUuid: c.Auth.Username,
+			Slug:      group.Slug,
+		}
+		err := c.Groups.Delete(opt)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}

--- a/bitbucket/provider.go
+++ b/bitbucket/provider.go
@@ -45,6 +45,7 @@ func Provider() *schema.Provider {
 			"bitbucket_default_reviewer":   resourceBitbucketDefaultReviewer(),
 			"bitbucket_deploy_key":         resourceBitbucketDeployKey(),
 			"bitbucket_group":              resourceBitbucketGroup(),
+			"bitbucket_group_member":       resourceBitbucketGroupMember(),
 			"bitbucket_group_permission":   resourceBitbucketGroupPermission(),
 			"bitbucket_project":            resourceBitbucketProject(),
 			"bitbucket_repository":         resourceBitbucketRepository(),

--- a/bitbucket/resource_bitbucket_group_member.go
+++ b/bitbucket/resource_bitbucket_group_member.go
@@ -1,0 +1,138 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	v1 "github.com/zahiar/terraform-provider-bitbucket/bitbucket/api/v1"
+)
+
+func resourceBitbucketGroupMember() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBitbucketGroupMemberCreate,
+		ReadContext:   resourceBitbucketGroupMemberRead,
+		DeleteContext: resourceBitbucketGroupMemberDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceBitbucketGroupMemberImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the group permission.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"workspace": {
+				Description: "The UUID (including the enclosing `{}`) of the workspace.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"group": {
+				Description: "The slug of the group.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"user": {
+				Description: "The User's UUID.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceBitbucketGroupMemberCreate(ctx context.Context, resourceData *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).V1
+
+	_, err := client.GroupMembers.Create(
+		&v1.GroupMemberOptions{
+			OwnerUuid: resourceData.Get("workspace").(string),
+			Slug:      resourceData.Get("group").(string),
+			UserUuid:  resourceData.Get("user").(string),
+		},
+	)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to create group member with error: %s", err))
+	}
+
+	return resourceBitbucketGroupMemberRead(ctx, resourceData, meta)
+}
+
+func resourceBitbucketGroupMemberRead(ctx context.Context, resourceData *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).V1
+
+	group, err := client.Groups.Get(
+		&v1.GroupOptions{
+			OwnerUuid: resourceData.Get("workspace").(string),
+			Slug:      resourceData.Get("group").(string),
+		},
+	)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to get group with error: %s", err))
+	}
+
+	groupMembers, err := client.GroupMembers.Get(
+		&v1.GroupMemberOptions{
+			OwnerUuid: resourceData.Get("workspace").(string),
+			Slug:      resourceData.Get("group").(string),
+			UserUuid:  resourceData.Get("user").(string),
+		},
+	)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to get group member with error: %s", err))
+	}
+
+	for _, member := range groupMembers {
+		if strings.EqualFold(resourceData.Get("user").(string), member.UUID) {
+			resourceData.SetId(generateGroupMemberId(group.Owner.Uuid, group.Slug, member.UUID))
+		}
+	}
+
+	return nil
+}
+
+func resourceBitbucketGroupMemberDelete(ctx context.Context, resourceData *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).V1
+
+	err := client.GroupMembers.Delete(
+		&v1.GroupMemberOptions{
+			OwnerUuid: resourceData.Get("workspace").(string),
+			Slug:      resourceData.Get("group").(string),
+			UserUuid:  resourceData.Get("user").(string),
+		},
+	)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to delete group member with error: %s", err))
+	}
+
+	resourceData.SetId("")
+
+	return nil
+}
+
+func resourceBitbucketGroupMemberImport(ctx context.Context, resourceData *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	ret := []*schema.ResourceData{resourceData}
+
+	splitID := strings.Split(resourceData.Id(), "/")
+	if len(splitID) < 3 {
+		return ret, fmt.Errorf("invalid import ID. It must to be in this format \"<workspace-uuid>/<group-slug>/<user-uuid>\"")
+	}
+
+	_ = resourceData.Set("workspace", splitID[0])
+	_ = resourceData.Set("group", splitID[1])
+	_ = resourceData.Set("user", splitID[2])
+
+	_ = resourceBitbucketGroupMemberRead(ctx, resourceData, meta)
+
+	return ret, nil
+}
+
+func generateGroupMemberId(workspace string, group string, user string) string {
+	return fmt.Sprintf("%s-%s-%s", workspace, group, user)
+}

--- a/bitbucket/resource_bitbucket_group_member_test.go
+++ b/bitbucket/resource_bitbucket_group_member_test.go
@@ -1,0 +1,72 @@
+package bitbucket
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccBitbucketGroupMemberResource_basic(t *testing.T) {
+	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	user, _ := getCurrentUser()
+	groupName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "bitbucket_workspace" "testacc" {
+						id = "%s"
+					}
+
+					data "bitbucket_user" "testacc" {
+						id = "%s"
+					}
+
+					resource "bitbucket_group" "testacc" {
+					  workspace  = data.bitbucket_workspace.testacc.uuid
+					  name       = "%s"
+                      auto_add   = true
+                      permission = "read"
+					}
+
+					resource "bitbucket_group_member" "testacc" {
+					  workspace = data.bitbucket_workspace.testacc.uuid
+					  group     = bitbucket_group.testacc.slug
+					  user      = data.bitbucket_user.testacc.id
+					}`, workspaceSlug, user.Uuid, groupName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("bitbucket_group_member.testacc", "workspace", user.Uuid),
+					resource.TestCheckResourceAttr("bitbucket_group_member.testacc", "group", groupName),
+					resource.TestCheckResourceAttr("bitbucket_group_member.testacc", "user", user.Uuid),
+
+					resource.TestCheckResourceAttrSet("bitbucket_group_member.testacc", "id"),
+				),
+			},
+			{
+				ResourceName:      "bitbucket_group_member.testacc",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.Modules[0].Resources
+					workspaceResourceAttr := resources["data.bitbucket_workspace.testacc"].Primary.Attributes
+					userResourceAttr := resources["data.bitbucket_user.testacc"].Primary.Attributes
+					return fmt.Sprintf("%s/%s/%s", workspaceResourceAttr["uuid"], groupName, userResourceAttr["id"]), nil
+				},
+			},
+		},
+	})
+}
+
+func TestGenerateGroupMemberResourceId(t *testing.T) {
+	expected := "{my-workspace-uuid}-my-test-group-{my-user-uuid}"
+	result := generateGroupPermissionResourceId("{my-workspace-uuid}", "my-test-group", "{my-user-uuid}")
+	assert.Equal(t, expected, result)
+}

--- a/docs/resources/bitbucket_group_member.md
+++ b/docs/resources/bitbucket_group_member.md
@@ -1,0 +1,29 @@
+# Resource: bitbucket_group_member
+Manage a user's membership in a group within Bitbucket.
+
+## Example Usage
+```hcl
+resource "bitbucket_group_member" "example" {
+  workspace = "{workspace-uuid}"
+  group     = "example-group"
+  user      = "{user-uuid}"
+}
+```
+
+## Argument Reference
+The following arguments are supported:
+* `workspace` - (Required) The UUID (including the enclosing `{}`) of the workspace.
+* `group` - (Required) The slug of the group.
+* `user` - (Required) The UUID (including the enclosing `{}`) of the user.
+
+## Attribute Reference
+In addition to the arguments above, the following additional attributes are exported:
+* `id` - The ID of the group membership.
+
+## Import
+Bitbucket group members can be imported with a combination of its workspace UUID, group slug & user UUID.
+
+### Example using workspace UUID, group slug & user UUID
+```sh
+$ terraform import bitbucket_group_permission.example "{123ab4cd-5678-9e01-f234-5678g9h01i2j}/example-group/{123ab4cd-5678-9e01-f234-5678g9h01i2j}"
+```


### PR DESCRIPTION
This PR adds a `bitbucket_group_member` resource, allowing users to be added as members to groups. Since BitBucket API v2 does not yet support this action, I've added a `GroupMembers` client to the `v1` package, implementing the [kind-of-deprecated AP](https://support.atlassian.com/bitbucket-cloud/docs/groups-endpoint/#GET-the-group-members).

Example:
```hcl
resource "bitbucket_group_member" "example" {
  workspace = "{workspace-uuid}"
  group     = "example-group"
  user      = "{user-uuid}"
}
```