### PR TITLE
Disable running CodeQL on pushes to main branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:


### PR DESCRIPTION
Only way for changes to get into the main branch is via a pull request (which runs CodeQL), no need to re-run CodeQL again when the pull request is merged.