### PR TITLE
GH-72 Gracefully handle no Group being returned

### DIFF
--- a/bitbucket/api/v1/groups.go
+++ b/bitbucket/api/v1/groups.go
@@ -57,6 +57,9 @@ func (g *Groups) Get(gro *GroupOptions) (*Group, error) {
 		log.Println("Could not unmarshal JSON payload")
 		return nil, err
 	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no group found")
+	}
 
 	return &result[0], nil
 }


### PR DESCRIPTION
If the slug is invalid/does not link to a group, then the API would not return an object thus leading to an `index out of bounds` error.