### PR TITLE
GH-77 Address bug with Branch Restriction plans

### DIFF
--- a/bitbucket/resource_bitbucket_branch_restriction.go
+++ b/bitbucket/resource_bitbucket_branch_restriction.go
@@ -138,6 +138,14 @@ func resourceBitbucketBranchRestrictionRead(ctx context.Context, resourceData *s
 		},
 	)
 	if err != nil {
+		// Handles a case whereby if the branch restrictions were deleted after being provisioned, Bitbucket's API
+		// returns a 404, so we treat that as the item having been deleted, therefore Terraform will re-provision
+		// if necessary.
+		if err.Error() == "404 Not Found" {
+			resourceData.SetId("")
+			return nil
+		}
+
 		return diag.FromErr(fmt.Errorf("unable to get branch restriction with error: %s", err))
 	}
 


### PR DESCRIPTION
Specifically when you provision a Branch Restriction via Terraform, and then delete it via the UI, this results in plans erroring, due to Bitbucket's API returning a 404. We now look for the 404 and treat that as the resource has been deleted.

fixes #77 