### PR TITLE
Replace deprecated GPG action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
         with:
           go-version: 1.19
 
-      - uses: hashicorp/ghaction-import-gpg@v2.1.0
+      - uses: crazy-max/ghaction-import-gpg@v5.1.0
         id: import_gpg
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
 
       - uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
Hashicorp originally created a fork to support sign-only keys until the upstream one did, now that it does, their's has been deprecated.
https://github.com/hashicorp/ghaction-import-gpg