### PR TITLE
GH-116 Update Groups implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.tfstate
 *.tfstate.backup
+examples

--- a/bitbucket/api/v1/groups.go
+++ b/bitbucket/api/v1/groups.go
@@ -19,7 +19,6 @@ type Group struct {
 		Uuid string `json:"uuid"`
 	}
 	Name       string `json:"name"`
-	AutoAdd    bool   `json:"auto_add"`
 	Slug       string `json:"slug"`
 	Permission string `json:"permission"`
 }
@@ -27,7 +26,6 @@ type Group struct {
 type GroupOptions struct {
 	OwnerUuid  string
 	Name       string
-	AutoAdd    bool
 	Slug       string
 	Permission string
 }
@@ -61,6 +59,10 @@ func (g *Groups) Get(gro *GroupOptions) (*Group, error) {
 		return nil, fmt.Errorf("no group found")
 	}
 
+	if result[0].Permission == "" {
+		result[0].Permission = "none"
+	}
+
 	return &result[0], nil
 }
 
@@ -92,20 +94,27 @@ func (g *Groups) Create(gro *GroupOptions) (*Group, error) {
 		return nil, err
 	}
 
+	if result.Permission == "" {
+		result.Permission = "none"
+	}
+
 	return result, nil
 }
 
 func (g *Groups) Update(gro *GroupOptions) (*Group, error) {
 	url := fmt.Sprintf("%s/groups/%s/%s", g.client.ApiBaseUrl, gro.OwnerUuid, gro.Slug)
 
+	groupPermission := &gro.Permission
+	if *groupPermission == "none" {
+		groupPermission = nil
+	}
+
 	requestBody := struct {
-		Name       string `json:"name,omitempty"`
-		AutoAdd    bool   `json:"auto_add,omitempty"`
-		Permission string `json:"permission,omitempty"`
+		Name       string  `json:"name,omitempty"`
+		Permission *string `json:"permission"`
 	}{
 		Name:       gro.Name,
-		AutoAdd:    gro.AutoAdd,
-		Permission: gro.Permission,
+		Permission: groupPermission,
 	}
 	requestBodyJson, err := json.Marshal(requestBody)
 	if err != nil {

--- a/bitbucket/api/v1/groups_test.go
+++ b/bitbucket/api/v1/groups_test.go
@@ -31,8 +31,7 @@ func TestGroups(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, name, group.Name)
-		assert.False(t, group.AutoAdd)
-		assert.Empty(t, group.Permission)
+		assert.Equal(t, "none", group.Permission)
 
 		groupResourceSlug = group.Slug
 	})
@@ -46,8 +45,7 @@ func TestGroups(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, name, group.Name)
-		assert.False(t, group.AutoAdd)
-		assert.Empty(t, group.Permission)
+		assert.Equal(t, "none", group.Permission)
 		assert.Equal(t, groupResourceSlug, group.Slug)
 	})
 
@@ -55,14 +53,12 @@ func TestGroups(t *testing.T) {
 		opt := &GroupOptions{
 			OwnerUuid:  c.Auth.Username,
 			Slug:       groupResourceSlug,
-			AutoAdd:    true,
 			Permission: "write",
 		}
 		group, err := c.Groups.Update(opt)
 
 		assert.NoError(t, err)
 		assert.Equal(t, name, group.Name)
-		assert.True(t, group.AutoAdd)
 		assert.Equal(t, "write", group.Permission)
 		assert.Equal(t, groupResourceSlug, group.Slug)
 	})
@@ -101,8 +97,7 @@ func TestGroupsGracefullyHandleNoReturnedGroupsForInvalidSlug(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, name, group.Name)
-		assert.False(t, group.AutoAdd)
-		assert.Empty(t, group.Permission)
+		assert.Equal(t, "none", group.Permission)
 
 		groupResourceSlug = group.Slug
 	})

--- a/bitbucket/data_source_bitbucket_group.go
+++ b/bitbucket/data_source_bitbucket_group.go
@@ -28,11 +28,6 @@ func dataSourceBitbucketGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"auto_add": {
-				Description: "Whether this group is auto-added to all future repositories.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-			},
 			"permission": {
 				Description: "The permission this group will have over repositories. Must be one of 'read', 'write', 'admin'.",
 				Type:        schema.TypeString,

--- a/bitbucket/data_source_bitbucket_group_permission_test.go
+++ b/bitbucket/data_source_bitbucket_group_permission_test.go
@@ -42,7 +42,6 @@ func TestAccBitbucketGroupPermissionDataSource_basic(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.uuid
 					  name       = "%s"
-					  auto_add   = true
 					  permission = "read"
 					}
 

--- a/bitbucket/data_source_bitbucket_group_test.go
+++ b/bitbucket/data_source_bitbucket_group_test.go
@@ -26,7 +26,6 @@ func TestAccBitbucketGroupDataSource_basic(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.id
 					  name       = "%s"
-					  auto_add   = true
 					  permission = "read"
 					}
 	
@@ -37,7 +36,6 @@ func TestAccBitbucketGroupDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.bitbucket_group.testacc", "workspace", workspaceSlug),
 					resource.TestCheckResourceAttr("data.bitbucket_group.testacc", "name", groupName),
-					resource.TestCheckResourceAttr("data.bitbucket_group.testacc", "auto_add", "true"),
 					resource.TestCheckResourceAttr("data.bitbucket_group.testacc", "permission", "read"),
 					resource.TestCheckResourceAttr("data.bitbucket_group.testacc", "slug", groupName),
 					resource.TestCheckResourceAttrSet("data.bitbucket_group.testacc", "id"),

--- a/bitbucket/resource_bitbucket_branch_restriction.go
+++ b/bitbucket/resource_bitbucket_branch_restriction.go
@@ -65,6 +65,7 @@ func resourceBitbucketBranchRestriction() *schema.Resource {
 					"reset_pullrequest_approvals_on_change",
 					"delete",
 				}, false),
+				ForceNew: true,
 			},
 			"value": {
 				Description: "A configurable value used by the following restrictions: `require_passing_builds_to_merge` uses it to define the number of minimum number of passing builds, `require_approvals_to_merge` uses it to define the minimum number of approvals before the PR can be merged, `require_default_reviewer_approvals_to_merge` uses it to define the minimum number of approvals from default reviewers before the PR can be merged.",

--- a/bitbucket/resource_bitbucket_group.go
+++ b/bitbucket/resource_bitbucket_group.go
@@ -42,17 +42,12 @@ func resourceBitbucketGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"auto_add": {
-				Description: "Whether this group is auto-added to all future repositories.",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-			},
 			"permission": {
-				Description:  "The permission this group will have over repositories. Must be one of 'read', 'write', 'admin'.",
+				Description:  "The global permission this group will have over all repositories. Must be one of 'none', 'read', 'write', 'admin'.",
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"read", "write", "admin"}, false),
+				Default:      "none",
+				ValidateFunc: validation.StringInSlice([]string{"none", "read", "write", "admin"}, false),
 			},
 		},
 	}
@@ -73,7 +68,7 @@ func resourceBitbucketGroupCreate(ctx context.Context, resourceData *schema.Reso
 
 	_ = resourceData.Set("slug", group.Slug)
 
-	// We do an update as well, as that's where the other options like auto-add/permissions are set.
+	// We do an update as well, as that's where the other options like permissions are set.
 	// The POST endpoint only accepts a name, and just creates a group without setting any other options.
 	return resourceBitbucketGroupUpdate(ctx, resourceData, meta)
 }
@@ -92,7 +87,6 @@ func resourceBitbucketGroupRead(ctx context.Context, resourceData *schema.Resour
 	}
 
 	_ = resourceData.Set("name", group.Name)
-	_ = resourceData.Set("auto_add", group.AutoAdd)
 	_ = resourceData.Set("permission", group.Permission)
 
 	resourceData.SetId(generateGroupResourceId(group.Owner.Uuid, group.Slug))
@@ -108,7 +102,6 @@ func resourceBitbucketGroupUpdate(ctx context.Context, resourceData *schema.Reso
 			OwnerUuid:  resourceData.Get("workspace").(string),
 			Slug:       resourceData.Get("slug").(string),
 			Name:       resourceData.Get("name").(string),
-			AutoAdd:    resourceData.Get("auto_add").(bool),
 			Permission: resourceData.Get("permission").(string),
 		},
 	)

--- a/bitbucket/resource_bitbucket_group_member_test.go
+++ b/bitbucket/resource_bitbucket_group_member_test.go
@@ -33,7 +33,6 @@ func TestAccBitbucketGroupMemberResource_basic(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.uuid
 					  name       = "%s"
-					  auto_add   = true
 					  permission = "read"
 					}
 

--- a/bitbucket/resource_bitbucket_group_permission_test.go
+++ b/bitbucket/resource_bitbucket_group_permission_test.go
@@ -44,7 +44,6 @@ func TestAccBitbucketGroupPermissionResource_basic(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.uuid
 					  name       = "%s"
-					  auto_add   = true
 					  permission = "read"
 					}
 

--- a/bitbucket/resource_bitbucket_group_test.go
+++ b/bitbucket/resource_bitbucket_group_test.go
@@ -28,12 +28,10 @@ func TestAccBitbucketGroupResource_basic(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.uuid
 					  name       = "%s"
-					  auto_add   = true
 					  permission = "read"
 					}`, workspaceSlug, groupName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "name", groupName),
-					resource.TestCheckResourceAttr("bitbucket_group.testacc", "auto_add", "true"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "permission", "read"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "slug", groupName),
 
@@ -73,12 +71,10 @@ func TestAccBitbucketGroupResource_changeName(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.uuid
 					  name       = "%s"
-					  auto_add   = true
 					  permission = "read"
 					}`, workspaceSlug, groupName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "name", groupName),
-					resource.TestCheckResourceAttr("bitbucket_group.testacc", "auto_add", "true"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "permission", "read"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "slug", groupName),
 
@@ -95,12 +91,10 @@ func TestAccBitbucketGroupResource_changeName(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.uuid
 					  name       = "%s"
-					  auto_add   = true
 					  permission = "read"
 					}`, workspaceSlug, newGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "name", newGroupName),
-					resource.TestCheckResourceAttr("bitbucket_group.testacc", "auto_add", "true"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "permission", "read"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "slug", newGroupName),
 
@@ -139,12 +133,10 @@ func TestAccBitbucketGroupResource_changeProperties(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.uuid
 					  name       = "%s"
-					  auto_add   = true
 					  permission = "read"
 					}`, workspaceSlug, groupName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "name", groupName),
-					resource.TestCheckResourceAttr("bitbucket_group.testacc", "auto_add", "true"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "permission", "read"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "slug", groupName),
 
@@ -161,12 +153,10 @@ func TestAccBitbucketGroupResource_changeProperties(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.uuid
 					  name       = "%s"
-					  auto_add   = false
 					  permission = "write"
 					}`, workspaceSlug, groupName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "name", groupName),
-					resource.TestCheckResourceAttr("bitbucket_group.testacc", "auto_add", "false"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "permission", "write"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "slug", groupName),
 
@@ -208,8 +198,7 @@ func TestAccBitbucketGroupResource_withoutProperties(t *testing.T) {
 					}`, workspaceSlug, groupName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "name", groupName),
-					resource.TestCheckResourceAttr("bitbucket_group.testacc", "auto_add", "false"),
-					resource.TestCheckResourceAttr("bitbucket_group.testacc", "permission", ""),
+					resource.TestCheckResourceAttr("bitbucket_group.testacc", "permission", "none"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "slug", groupName),
 
 					resource.TestCheckResourceAttrSet("bitbucket_group.testacc", "workspace"),
@@ -225,12 +214,10 @@ func TestAccBitbucketGroupResource_withoutProperties(t *testing.T) {
 					resource "bitbucket_group" "testacc" {
 					  workspace  = data.bitbucket_workspace.testacc.uuid
 					  name       = "%s"
-					  auto_add   = true
 					  permission = "write"
 					}`, workspaceSlug, groupName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "name", groupName),
-					resource.TestCheckResourceAttr("bitbucket_group.testacc", "auto_add", "true"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "permission", "write"),
 					resource.TestCheckResourceAttr("bitbucket_group.testacc", "slug", groupName),
 

--- a/bitbucket/resource_bitbucket_repository_test.go
+++ b/bitbucket/resource_bitbucket_repository_test.go
@@ -47,7 +47,7 @@ func TestAccBitbucketRepositoryResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "project_key", projectKey),
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "description", ""),
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "is_private", "true"),
-					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "has_wiki", "true"),
+					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "has_wiki", "false"),
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "fork_policy", "no_forks"),
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "enable_pipelines", "false"),
 					resource.TestCheckResourceAttrSet("bitbucket_repository.testacc", "id"),
@@ -78,7 +78,7 @@ func TestAccBitbucketRepositoryResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "project_key", projectKey),
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "description", repoDescription),
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "is_private", "true"),
-					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "has_wiki", "true"),
+					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "has_wiki", "false"),
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "fork_policy", repoForkPolicy),
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "enable_pipelines", "false"),
 					resource.TestCheckResourceAttrSet("bitbucket_repository.testacc", "id"),
@@ -103,6 +103,7 @@ func TestAccBitbucketRepositoryResource_basic(t *testing.T) {
 					  description      = "%s"
 					  fork_policy      = "%s"
 					  enable_pipelines = true
+					  has_wiki         = true
 					}`, workspaceSlug, projectName, projectKey, repoName, repoDescription, repoForkPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("bitbucket_repository.testacc", "workspace", workspaceSlug),
@@ -133,7 +134,7 @@ func TestValidateRepositoryName(t *testing.T) {
 	validator := validateRepositoryName(invalidName, nil)
 	assert.True(t, validator.HasError())
 
-	validNames := []string{"abc-def","foo.bar"}
+	validNames := []string{"abc-def", "foo.bar"}
 
 	for _, validName := range validNames {
 		validator = validateRepositoryName(validName, nil)

--- a/docs/data-sources/bitbucket_group.md
+++ b/docs/data-sources/bitbucket_group.md
@@ -18,5 +18,4 @@ The following arguments are supported:
 In addition to the arguments above, the following additional attributes are exported:
 * `id` - The ID of the group.
 * `name` - A human-readable name of the group.
-* `auto_add` - A boolean to state whether this group is auto-added to all future repositories.
-* `permission` - The permission this group will have over repositories. Is one of 'read', 'write', or 'admin'.
+* `permission` - The global permission this group will have over all repositories. Is one of 'none', 'read', 'write', 'admin'.

--- a/docs/resources/bitbucket_group.md
+++ b/docs/resources/bitbucket_group.md
@@ -6,7 +6,6 @@ Manage a group within Bitbucket.
 resource "bitbucket_group" "example" {
   workspace  = "{workspace-uuid}"
   name       = "Example Group"
-  auto_add   = false
   permission = "read"
 }
 ```
@@ -15,8 +14,7 @@ resource "bitbucket_group" "example" {
 The following arguments are supported:
 * `workspace` - (Required) The UUID (including the enclosing `{}`) of the workspace the group belongs to.
 * `name` - (Required) A human-readable name of the group.
-* `auto_add` - (Optional) A boolean to state whether this group is auto-added to all future repositories.
-* `permission` - (Optional) The permission this group will have over repositories. Is one of 'read', 'write', or 'admin'.
+* `permission` - (Optional) The global permission this group will have over all repositories. Must be one of 'none', 'read', 'write', 'admin'.
 
 ## Attribute Reference
 In addition to the arguments above, the following additional attributes are exported:


### PR DESCRIPTION
This is to match the latest Bitbucket behaviour, specifically the `auto_add` has been replaced by an additional permission entry `none`. Appears as though groups are auto-added to all repositories with a default permission, that can then be overridden on a per-repository basis.