### PR TITLE
fix: Allow specifying the workspace name separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ tests to run, as Bitbucket's API will reject the account owner's UUID.
 * `BITBUCKET_USERNAME` - Username of the account to run the tests against
 * `BITBUCKET_PASSWORD` - Password of the account to run the tests against
 * `BITBUCKET_MEMBER_ACCOUNT_UUID` - Account UUID of the member who is part of your account
+* `BITBUCKET_WORKSPACE` - Set this, if the workspace name differs from the username.
 
 **NOTE**: if a test fails, it may leave dangling resources in your account so please bear this in mind.
 

--- a/bitbucket/api/v1/group_members_test.go
+++ b/bitbucket/api/v1/group_members_test.go
@@ -19,11 +19,12 @@ func TestGroupMembers(t *testing.T) {
 	})
 
 	var group *Group
+	owner := os.Getenv("BITBUCKET_WORKSPACE")
 
 	t.Run("setup", func(t *testing.T) {
 		group, _ = c.Groups.Create(
 			&GroupOptions{
-				OwnerUuid: c.Auth.Username,
+				OwnerUuid: owner,
 				Name:      "tf-bb-group-members-test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum),
 			},
 		)
@@ -33,7 +34,7 @@ func TestGroupMembers(t *testing.T) {
 	t.Run("create", func(t *testing.T) {
 		result, err := c.GroupMembers.Create(
 			&GroupMemberOptions{
-				OwnerUuid: c.Auth.Username,
+				OwnerUuid: owner,
 				Slug:      group.Slug,
 				UserUuid:  group.Owner.Uuid,
 			},
@@ -47,7 +48,7 @@ func TestGroupMembers(t *testing.T) {
 	t.Run("get", func(t *testing.T) {
 		members, err := c.GroupMembers.Get(
 			&GroupMemberOptions{
-				OwnerUuid: c.Auth.Username,
+				OwnerUuid: owner,
 				Slug:      group.Slug,
 			},
 		)
@@ -60,7 +61,7 @@ func TestGroupMembers(t *testing.T) {
 	t.Run("delete", func(t *testing.T) {
 		err := c.GroupMembers.Delete(
 			&GroupMemberOptions{
-				OwnerUuid: c.Auth.Username,
+				OwnerUuid: owner,
 				Slug:      group.Slug,
 				UserUuid:  group.Owner.Uuid,
 			},
@@ -69,7 +70,7 @@ func TestGroupMembers(t *testing.T) {
 
 		members, err := c.GroupMembers.Get(
 			&GroupMemberOptions{
-				OwnerUuid: c.Auth.Username,
+				OwnerUuid: owner,
 				Slug:      group.Slug,
 			},
 		)
@@ -79,7 +80,7 @@ func TestGroupMembers(t *testing.T) {
 
 	t.Run("teardown", func(t *testing.T) {
 		opt := &GroupOptions{
-			OwnerUuid: c.Auth.Username,
+			OwnerUuid: owner,
 			Slug:      group.Slug,
 		}
 		err := c.Groups.Delete(opt)

--- a/bitbucket/api/v1/groups_test.go
+++ b/bitbucket/api/v1/groups_test.go
@@ -21,10 +21,11 @@ func TestGroups(t *testing.T) {
 	var groupResourceSlug string
 
 	name := "tf-bb-group-test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	owner := os.Getenv("BITBUCKET_WORKSPACE")
 
 	t.Run("create", func(t *testing.T) {
 		opt := &GroupOptions{
-			OwnerUuid: c.Auth.Username,
+			OwnerUuid: owner,
 			Name:      name,
 		}
 
@@ -66,7 +67,7 @@ func TestGroups(t *testing.T) {
 
 	t.Run("delete", func(t *testing.T) {
 		opt := &GroupOptions{
-			OwnerUuid: c.Auth.Username,
+			OwnerUuid: owner,
 			Slug:      groupResourceSlug,
 		}
 		err := c.Groups.Delete(opt)
@@ -87,10 +88,11 @@ func TestGroupsGracefullyHandleNoReturnedGroupsForInvalidSlug(t *testing.T) {
 	var groupResourceSlug string
 
 	name := "TF-BB-Group-Test"
+	owner := os.Getenv("BITBUCKET_WORKSPACE")
 
 	t.Run("create", func(t *testing.T) {
 		opt := &GroupOptions{
-			OwnerUuid: c.Auth.Username,
+			OwnerUuid: owner,
 			Name:      name,
 		}
 
@@ -105,7 +107,7 @@ func TestGroupsGracefullyHandleNoReturnedGroupsForInvalidSlug(t *testing.T) {
 
 	t.Run("get", func(t *testing.T) {
 		opt := &GroupOptions{
-			OwnerUuid: c.Auth.Username,
+			OwnerUuid: owner,
 			Slug:      name, // Slugs are lowercase and the BB's API is case-sensitive, this will trigger a fail response
 		}
 		group, err := c.Groups.Get(opt)
@@ -115,7 +117,7 @@ func TestGroupsGracefullyHandleNoReturnedGroupsForInvalidSlug(t *testing.T) {
 
 	t.Run("delete", func(t *testing.T) {
 		opt := &GroupOptions{
-			OwnerUuid: c.Auth.Username,
+			OwnerUuid: owner,
 			Slug:      groupResourceSlug,
 		}
 		err := c.Groups.Delete(opt)

--- a/bitbucket/data_source_bitbucket_branch_restriction_test.go
+++ b/bitbucket/data_source_bitbucket_branch_restriction_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccBitbucketBranchRestrictionDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -71,7 +71,7 @@ func TestAccBitbucketBranchRestrictionDataSource_basic(t *testing.T) {
 }
 
 func TestAccBitbucketBranchRestrictionDataSource_withKindAndValueCombination(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_default_reviewer_test.go
+++ b/bitbucket/data_source_bitbucket_default_reviewer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketDefaultReviewerDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_deploy_key_test.go
+++ b/bitbucket/data_source_bitbucket_deploy_key_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketDeployKeyDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -67,7 +67,7 @@ func TestAccBitbucketDeployKeyDataSource_basic(t *testing.T) {
 }
 
 func TestAccBitbucketDeployKeyDataSource_keyWithComment(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_deployment_test.go
+++ b/bitbucket/data_source_bitbucket_deployment_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketDeploymentDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_deployment_variable_test.go
+++ b/bitbucket/data_source_bitbucket_deployment_variable_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketDeploymentVariableDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_group_permission_test.go
+++ b/bitbucket/data_source_bitbucket_group_permission_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketGroupPermissionDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_group_test.go
+++ b/bitbucket/data_source_bitbucket_group_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccBitbucketGroupDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	groupName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{

--- a/bitbucket/data_source_bitbucket_pipeline_variable_test.go
+++ b/bitbucket/data_source_bitbucket_pipeline_variable_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketPipelineVariableDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_project_test.go
+++ b/bitbucket/data_source_bitbucket_project_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketProjectDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	projectDescription := "TF ACC Test Project"

--- a/bitbucket/data_source_bitbucket_repository_test.go
+++ b/bitbucket/data_source_bitbucket_repository_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketRepositoryDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_user_permission_test.go
+++ b/bitbucket/data_source_bitbucket_user_permission_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketUserPermissionDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_user_workspace_test.go
+++ b/bitbucket/data_source_bitbucket_user_workspace_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccBitbucketUserWorkspaceDataSource_basic(t *testing.T) {
-	workspace := os.Getenv("BITBUCKET_USERNAME")
+	workspace := os.Getenv("BITBUCKET_WORKSPACE")
 	user, _ := getCurrentUser()
 
 	resource.Test(t, resource.TestCase{

--- a/bitbucket/data_source_bitbucket_webhook_test.go
+++ b/bitbucket/data_source_bitbucket_webhook_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketWebhookDataSource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/data_source_bitbucket_workspace_test.go
+++ b/bitbucket/data_source_bitbucket_workspace_test.go
@@ -17,9 +17,9 @@ func TestAccBitbucketWorkspaceDataSource_basic(t *testing.T) {
 				Config: fmt.Sprintf(`
 					data "bitbucket_workspace" "testacc" {
 						id = "%s"
-					}`, os.Getenv("BITBUCKET_USERNAME")),
+					}`, os.Getenv("BITBUCKET_WORKSPACE")),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.bitbucket_workspace.testacc", "id", os.Getenv("BITBUCKET_USERNAME")),
+					resource.TestCheckResourceAttr("data.bitbucket_workspace.testacc", "id", os.Getenv("BITBUCKET_WORKSPACE")),
 					resource.TestCheckResourceAttr("data.bitbucket_workspace.testacc", "type", "workspace"),
 					resource.TestCheckResourceAttrSet("data.bitbucket_workspace.testacc", "uuid"),
 					resource.TestCheckResourceAttrSet("data.bitbucket_workspace.testacc", "is_private"),

--- a/bitbucket/provider_test.go
+++ b/bitbucket/provider_test.go
@@ -12,6 +12,11 @@ var testAccProvider *schema.Provider
 var testAccProviders map[string]func() (*schema.Provider, error)
 
 func init() {
+	workspace := os.Getenv("BITBUCKET_WORKSPACE")
+	if workspace == "" {
+		os.Setenv("BITBUCKET_WORKSPACE", os.Getenv("BITBUCKET_USERNAME"))
+	}
+
 	testAccProvider = Provider()
 	testAccProviders = map[string]func() (*schema.Provider, error){
 		"bitbucket": func() (*schema.Provider, error) {

--- a/bitbucket/resource_bitbucket_branch_restriction_test.go
+++ b/bitbucket/resource_bitbucket_branch_restriction_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccBitbucketBranchRestrictionResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -77,7 +77,7 @@ func TestAccBitbucketBranchRestrictionResource_basic(t *testing.T) {
 }
 
 func TestAccBitbucketBranchRestrictionResource_withKindAndValueCombination(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -142,7 +142,7 @@ func TestAccBitbucketBranchRestrictionResource_withKindAndValueCombination(t *te
 }
 
 func TestAccBitbucketBranchRestrictionResource_withUsers(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -221,7 +221,7 @@ func TestAccBitbucketBranchRestrictionResource_withUsers(t *testing.T) {
 }
 
 func TestAccBitbucketBranchRestrictionResource_withGroups(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -314,7 +314,7 @@ func TestAccBitbucketBranchRestrictionResource_withGroups(t *testing.T) {
 }
 
 func TestAccBitbucketBranchRestrictionResource_withUsersAndGroups(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -410,7 +410,7 @@ func TestAccBitbucketBranchRestrictionResource_withUsersAndGroups(t *testing.T) 
 }
 
 func TestAccBitbucketBranchRestrictionResource_withEmptyUsersAndEmptyGroups(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_default_reviewer_test.go
+++ b/bitbucket/resource_bitbucket_default_reviewer_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccBitbucketDefaultReviewerResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_deploy_key_test.go
+++ b/bitbucket/resource_bitbucket_deploy_key_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccBitbucketDeployKeyResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -71,7 +71,7 @@ func TestAccBitbucketDeployKeyResource_basic(t *testing.T) {
 }
 
 func TestAccBitbucketDeployKeyResource_keyWithComment(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_deployment_test.go
+++ b/bitbucket/resource_bitbucket_deployment_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccBitbucketDeploymentResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_deployment_variable_test.go
+++ b/bitbucket/resource_bitbucket_deployment_variable_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBitbucketDeploymentVariableResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -120,7 +120,7 @@ func TestAccBitbucketDeploymentVariableResource_basic(t *testing.T) {
 }
 
 func TestAccBitbucketDeploymentVariableResource_multipleVars(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_group_member_test.go
+++ b/bitbucket/resource_bitbucket_group_member_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccBitbucketGroupMemberResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	user, _ := getCurrentUser()
 	groupName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 

--- a/bitbucket/resource_bitbucket_group_permission_test.go
+++ b/bitbucket/resource_bitbucket_group_permission_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccBitbucketGroupPermissionResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_group_test.go
+++ b/bitbucket/resource_bitbucket_group_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccBitbucketGroupResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	groupName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
@@ -54,7 +54,7 @@ func TestAccBitbucketGroupResource_basic(t *testing.T) {
 }
 
 func TestAccBitbucketGroupResource_changeName(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	groupName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	newGroupName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
@@ -117,7 +117,7 @@ func TestAccBitbucketGroupResource_changeName(t *testing.T) {
 }
 
 func TestAccBitbucketGroupResource_changeProperties(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	groupName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
@@ -179,7 +179,7 @@ func TestAccBitbucketGroupResource_changeProperties(t *testing.T) {
 }
 
 func TestAccBitbucketGroupResource_withoutProperties(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	groupName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{

--- a/bitbucket/resource_bitbucket_pipeline_key_pair_test.go
+++ b/bitbucket/resource_bitbucket_pipeline_key_pair_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccBitbucketPipelineKeyPairResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_pipeline_variable_test.go
+++ b/bitbucket/resource_bitbucket_pipeline_variable_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccBitbucketPipelineVariableResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_project_test.go
+++ b/bitbucket/resource_bitbucket_project_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccBitbucketProjectResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	projectDescription := "TF ACC Test Project"

--- a/bitbucket/resource_bitbucket_repository_test.go
+++ b/bitbucket/resource_bitbucket_repository_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccBitbucketRepositoryResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_user_permission_test.go
+++ b/bitbucket/resource_bitbucket_user_permission_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccBitbucketUserPermissionResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/bitbucket/resource_bitbucket_webhook_test.go
+++ b/bitbucket/resource_bitbucket_webhook_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccBitbucketWebhookResource_basic(t *testing.T) {
-	workspaceSlug := os.Getenv("BITBUCKET_USERNAME")
+	workspaceSlug := os.Getenv("BITBUCKET_WORKSPACE")
 	projectName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	projectKey := strings.ToUpper(acctest.RandStringFromCharSet(3, acctest.CharSetAlpha))
 	repoName := "tf-acc-test-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)


### PR DESCRIPTION
For cases where it differs from the username, which is the case in my environment.
Falls back to username if not specified