### PR TITLE
Add 'ForceNew' to 'repository' parameter of 'bitbucket_pipeline_variable'

### DIFF
--- a/bitbucket/resource_bitbucket_pipeline_variable.go
+++ b/bitbucket/resource_bitbucket_pipeline_variable.go
@@ -36,6 +36,7 @@ func resourceBitbucketPipelineVariable() *schema.Resource {
 				Description:      "The name of the repository (must consist of only lowercase ASCII letters, numbers, underscores and hyphens).",
 				Type:             schema.TypeString,
 				Required:         true,
+				ForceNew:         true,
 				ValidateDiagFunc: validateRepositoryName,
 			},
 			"key": {


### PR DESCRIPTION
The Bitbucket API does not provide the capability to change the 'repository' parameter of a pipeline variable (results in 404 error when trying to do so). This resource needs to be re-created if the 'repository' parameter changes. This update adds the 'ForceNew' parameter to make sure this happens.

https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew