### PR TITLE
Read rank of deployment from environment_type

### DIFF
--- a/bitbucket/resource_bitbucket_deployment.go
+++ b/bitbucket/resource_bitbucket_deployment.go
@@ -97,7 +97,7 @@ func resourceBitbucketDeploymentRead(ctx context.Context, resourceData *schema.R
 	}
 
 	_ = resourceData.Set("name", deployment.Name)
-	_ = resourceData.Set("environment", gobb.RepositoryEnvironmentTypeOption(deployment.Rank).String())
+	_ = resourceData.Set("environment", gobb.RepositoryEnvironmentTypeOption(deployment.EnvironmentType.Rank).String())
 	resourceData.SetId(deployment.Uuid)
 
 	return nil


### PR DESCRIPTION
The documentation from bitbucket is actually not that good, because it doesn't explain any of the fields in question. However I observed on the bitbucket-cloud instance that the previous implementation lead to errors during imports of deployment configurations into a terraform state.

Steps to reproduce the error:
1. Create a repository in bitbucket-cloud
2. Create a deployment for the repository via GUI for Production or Staging (not Test!)
3. write a terraform module (which exactly matches the deployment) and perform `terraform import` to import the existing deployment into the terraform state
4. perform `terraform apply` and terraform wants to change the resource!

This change reads the rank from the `environment_type` which is the only valid source if the deployment was created via UI and still a valid source for a deployment which was created via this provider.

Reference: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-deployments/#api-repositories-workspace-repo-slug-environments-environment-uuid-get-response
Closes: #186